### PR TITLE
Release 4.5.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,6 +274,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-20
+  x86_64-darwin-21
 
 DEPENDENCIES
   cocoapods

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
   - Nuke (10.5.2)
   - Starscream (4.0.4)
-  - StreamChat (4.5.1):
+  - StreamChat (4.5.2):
     - Starscream (~> 4.0)
-  - StreamChatUI (4.5.1):
+  - StreamChatUI (4.5.2):
     - Nuke (~> 10.0)
-    - StreamChat (= 4.5.1)
+    - StreamChat (= 4.5.2)
     - SwiftyGif (~> 5.4)
   - SwiftyGif (5.4.1)
 
@@ -23,8 +23,8 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   Nuke: 62d6d401e2b3ce553151a6f5e2f9332878710fbd
   Starscream: 5178aed56b316f13fa3bc55694e583d35dd414d9
-  StreamChat: b5d0f93c3355a0d0211506be3da2c1c9680a2aa1
-  StreamChatUI: 4e8d01cb5d5f0f99faf2622c4870edbe65f6d95d
+  StreamChat: db2da43871cd6390f072e08ab58d237683cd9f30
+  StreamChatUI: 4039ea29a2445a4dae9004d0c92ed139c88d1d1f
   SwiftyGif: 6895c887f5551618a3c5dd3ecb512419105bacca
 
 PODFILE CHECKSUM: 00f05d8b92e06b80e9bab6773742f1f71d119503

--- a/StreamChatIntegration.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/StreamChatIntegration.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/kean/Nuke.git",
         "state": {
           "branch": null,
-          "revision": "472a03c15f39592007d94f25abe554350bc8aa2b",
-          "version": "10.5.1"
+          "revision": "6be3e778f1663b16dd645b7e8a0a01f73b5ed7f3",
+          "version": "10.5.2"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/GetStream/stream-chat-swift.git",
         "state": {
           "branch": null,
-          "revision": "c046bb93901dd109d99ebf4fe47d498dba19d408",
-          "version": "4.5.1"
+          "revision": "0c91b57ef417f646b4f9aec3dd9b053e049859f9",
+          "version": "4.5.2"
         }
       },
       {


### PR DESCRIPTION
### 🔗 Issue Link

CIS-1396

### 🎯 Goal

Verify `4.5.2` does not break CocoaPods/Cartage/SPM inegration

### 🛠 Implementation

N/A

### 🧪 Testing

Let the CI run and see if it's green

### 🎨 Changes

Bump vesrtions of **StreamChat/StreamChatUI** to `4.5.2`

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
