### PR TITLE
Release 4.8.0

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - StreamChat (4.7.0)
-  - StreamChatUI (4.7.0):
-    - StreamChat (= 4.7.0)
+  - StreamChat (4.8.0)
+  - StreamChatUI (4.8.0):
+    - StreamChat (= 4.8.0)
 
 DEPENDENCIES:
   - StreamChatUI
@@ -12,8 +12,8 @@ SPEC REPOS:
     - StreamChatUI
 
 SPEC CHECKSUMS:
-  StreamChat: a2d41e6ef9364c1153ee0eb290adfa7f39a9ba47
-  StreamChatUI: c92724df1160ab0686ccd131b3f101acc7a9cec9
+  StreamChat: 843be9e275a1efe5f8e384ad321d0893c74a46cc
+  StreamChatUI: d37b9dc0f0a79e12ffd85779fe6a1fbcc2ba280e
 
 PODFILE CHECKSUM: 00f05d8b92e06b80e9bab6773742f1f71d119503
 

--- a/StreamChatIntegration-SPM.xcodeproj/project.pbxproj
+++ b/StreamChatIntegration-SPM.xcodeproj/project.pbxproj
@@ -372,7 +372,7 @@
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
 				kind = exactVersion;
-				version = '4.7.0';
+				version = '4.8.0';
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/StreamChatIntegration.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/StreamChatIntegration.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/GetStream/stream-chat-swift.git",
         "state": {
           "branch": null,
-          "revision": "c0a435a7cdce7959d65178c7c78ffc1a6e05227b",
-          "version": "4.7.0"
+          "revision": "1edabbeef14668b2211737f211e23dece695d6e3",
+          "version": "4.8.0"
         }
       }
     ]

--- a/XCIntegration/Podfile.lock
+++ b/XCIntegration/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - StreamChat-XCFramework (4.7.0)
-  - StreamChatUI-XCFramework (4.7.0):
-    - StreamChat-XCFramework (= 4.7.0)
+  - StreamChat-XCFramework (4.8.0)
+  - StreamChatUI-XCFramework (4.8.0):
+    - StreamChat-XCFramework (= 4.8.0)
 
 DEPENDENCIES:
   - StreamChatUI-XCFramework
@@ -12,8 +12,8 @@ SPEC REPOS:
     - StreamChatUI-XCFramework
 
 SPEC CHECKSUMS:
-  StreamChat-XCFramework: 570d1f384d1228f6d344492b52cf815631bfdc05
-  StreamChatUI-XCFramework: 10aeba7738fc45e68d3b19f69854de73b537e8c2
+  StreamChat-XCFramework: 8862f40104d5dd76667bb81fa4be3d8b24e57a88
+  StreamChatUI-XCFramework: e112378075850d0617ea679fac782048e15e776d
 
 PODFILE CHECKSUM: 0d5f7b6ba638150cc666757002db9b3cb980eaac
 

--- a/XCIntegration/StreamChatIntegration-XC-Carthage.xcodeproj/project.pbxproj
+++ b/XCIntegration/StreamChatIntegration-XC-Carthage.xcodeproj/project.pbxproj
@@ -313,9 +313,9 @@
 				INFOPLIST_FILE = ../StreamChatIntegrationSource/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -341,9 +341,9 @@
 				INFOPLIST_FILE = ../StreamChatIntegrationSource/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/XCIntegration/StreamChatIntegration-XC-CocoaPods.xcodeproj/project.pbxproj
+++ b/XCIntegration/StreamChatIntegration-XC-CocoaPods.xcodeproj/project.pbxproj
@@ -356,9 +356,9 @@
 				INFOPLIST_FILE = ../StreamChatIntegrationSource/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -385,9 +385,9 @@
 				INFOPLIST_FILE = ../StreamChatIntegrationSource/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/XCIntegration/StreamChatIntegration-XC-SPM.xcodeproj/project.pbxproj
+++ b/XCIntegration/StreamChatIntegration-XC-SPM.xcodeproj/project.pbxproj
@@ -298,9 +298,9 @@
 				INFOPLIST_FILE = ../StreamChatIntegrationSource/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -326,9 +326,9 @@
 				INFOPLIST_FILE = ../StreamChatIntegrationSource/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/XCIntegration/StreamChatIntegration-XC.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XCIntegration/StreamChatIntegration-XC.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/GetStream/stream-chat-swift-spm.git",
         "state": {
           "branch": null,
-          "revision": "95350af88585ab688d31f42137de3308f72608ed",
-          "version": "4.6.0"
+          "revision": "cc31f6a16ffb4219363fedd61fdc86a63770e98d",
+          "version": "4.8.0"
         }
       }
     ]

--- a/XCIntegration/fastlane/Fastfile
+++ b/XCIntegration/fastlane/Fastfile
@@ -1,0 +1,15 @@
+default_platform(:ios)
+
+platform :ios do
+
+  desc "Build XC Integration App"
+  lane :build_xc_integration_app do |options|
+    build_app(
+      workspace: "StreamChatIntegration-XC.xcworkspace",
+      scheme: options[:scheme],
+      skip_archive: true,
+      skip_codesigning: true
+    )
+  end
+
+end

--- a/XCIntegration/fastlane/README.md
+++ b/XCIntegration/fastlane/README.md
@@ -15,21 +15,13 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 ## iOS
 
-### ios build_oss_integration_app
+### ios build_xc_integration_app
 
 ```sh
-[bundle exec] fastlane ios build_oss_integration_app
+[bundle exec] fastlane ios build_xc_integration_app
 ```
 
-Build OSS Integration App
-
-### ios test_release
-
-```sh
-[bundle exec] fastlane ios test_release
-```
-
-Start a new release
+Build XC Integration App
 
 ----
 

--- a/XCIntegration/fastlane/report.xml
+++ b/XCIntegration/fastlane/report.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="fastlane.lanes">
+    
+    
+    
+      
+      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.000289">
+        
+      </testcase>
+    
+      
+      <testcase classname="fastlane.lanes" name="1: build_app" time="23.334011">
+        
+      </testcase>
+    
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
### 🎯 Goal
Test release 4.8.0

### 🎨 Changes
* Release 4.8.0
* Adds lane to build xc apps into `XCIntegration` fastlane folder
* Main storyboard removed from xc integration apps
* XC Integration apps can now be built against iOS 11.0.

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
